### PR TITLE
Alert User is already subscribed

### DIFF
--- a/backend/router/contact/create-contact.ts
+++ b/backend/router/contact/create-contact.ts
@@ -9,7 +9,9 @@ export async function createNewsletterForm(email: string) {
     },
   })
   if (user) {
-    return user
+    return {
+      message: 'You are already subscribed!',
+    }
   }
   await prisma.user.create({
     data: {
@@ -17,4 +19,7 @@ export async function createNewsletterForm(email: string) {
       newsletter: true,
     },
   })
+  return {
+    message: 'Subscribed!',
+  }
 }

--- a/src/components/Footer/FooterNewsletter.tsx
+++ b/src/components/Footer/FooterNewsletter.tsx
@@ -55,7 +55,7 @@ export default function FooterNewsletter() {
         disabled={submit}
         className="w-full px-3 py-1 text-base font-bold transition-all duration-300 ease-linear bg-white border-2 border-black elative rounded-xl hover:shadow-none focus-within:shadow-none hover:bg-black hover:text-white shadow-deep focus:bg-green-light disabled:bg-green-light disabled:shadow-none disabled:pointer-events-none focus-within:text-black outline-none focus:ring-4 focus:ring-secondary-light"
       >
-        {isSuccess ? 'Subscribed!' : 'Subscribe'}
+        {isSuccess ? contactRouter.data?.message : 'Subscribe'}
         {isError ?? contactRouter.error?.message}
       </button>
     </Form>


### PR DESCRIPTION
## Highlights
- on `create-contact` return valid message
- use `contactRouter` to access message on` FooterNewsletter`

## Relates to 
- Implements: #10 

## Thoughts
Arguably it could be a 422 validation error, though this simple approach gets the job done.

Also this may not be the ideal type of UX looking at different newsletters, most share this flow
Message telling User to check their inbox (always) --> Approving the link on their inbox
- https://planetscale.com/blog
- https://usefathom.com/blog
- https://tailwindcss.com/blog

That being said, since in our case we are essentially creating Users, it may make sense to approach it in this style